### PR TITLE
Default MAX_NUM_BATCHED_TOKENS to 2048 — the profiler charges the KV pool for it

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Served model name: `deepseek-v4-flash-0731`. API: `http://127.0.0.1:8888/v1` (Op
 |---|---|---|
 | `MAX_MODEL_LEN` | 384000 | ~13% under the worst-observed cold-boot pool (439,622 tokens); lower it if a boot ever fails the KV check |
 | `MAX_NUM_SEQS` | 1 | `start.sh` default (single deep-context request; raise for concurrency — the pool shrinks with seq count via the hybrid cache split, e.g. 2 seqs ≈ 337k total) |
-| `MAX_NUM_BATCHED_TOKENS` | 8224 | prefill budget |
+| `MAX_NUM_BATCHED_TOKENS` | 2048 | prefill budget **and** the size of the profiler's dummy forward — vLLM subtracts that "peak activation" from the KV pool. 8224 reserves 5.30 GiB, 2048 reserves 1.39 GiB, at equal prefill throughput (997 vs 1013 tok/s on the same 60k prompt) because `LONG_PREFILL_TOKEN_THRESHOLD` already caps what a step allocates |
 | `GPU_MEMORY_UTILIZATION` | 0.94 | **max this host boots at** (see KV section) |
 | `VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS` | 0 | removes the profiler's ~0.68 GiB graph over-reservation (real usage is 0.07 GiB) → grows KV |
 | `LONG_PREFILL_TOKEN_THRESHOLD` | 1024 | caps prefill chunks; prevents decode starvation (0=off) |

--- a/start.sh
+++ b/start.sh
@@ -64,7 +64,7 @@ IMAGE_DIGEST="ghcr.io/0xsero/deepseek-v4-flash-0731-spark-sparkinfer@sha256:2e07
 SERVED_MODEL_NAME="${SERVED_MODEL_NAME:-deepseek-v4-flash-0731}"
 MAX_MODEL_LEN="${MAX_MODEL_LEN:-384000}"   # single deep context: ~13% under the worst observed cold-boot pool (439,622 tokens, util 0.94). If a boot ever fails the "KV cache needed" check, lower this.
 MAX_NUM_SEQS="${MAX_NUM_SEQS:-1}"          # single-request deep-context server; raise for concurrent slots (the pool itself shrinks with seq count — hybrid cache split; 2 seqs observed ~337k total, ~169k each)
-MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-8224}"
+MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-2048}"   # ALSO sizes the profiler dummy forward, whose "peak activation" vLLM subtracts from the KV pool: 8224 reserves 5.30 GiB, 2048 reserves 1.39 GiB. Prefill is unchanged (997 vs 1013 tok/s on the same 60k prompt, cached_tokens=0) because LONG_PREFILL_TOKEN_THRESHOLD=1024 already caps the per-step allocation
 MODE="${MODE:-dspark}"                 # fixed K5 DSpark speculative draft
 GPU_MEMORY_UTILIZATION="${GPU_MEMORY_UTILIZATION:-0.94}"   # 256k needs the extra ~1.2 GiB (0.93 leaves only 6.32 GiB KV < 6.99 needed). Boot-safe BECAUSE restart: on-failure:1 can never loop: worst case one clean exit. Requires free host RAM >= 0.94*121.63 = 114.3 GiB at launch (check free -h; stop the old container first).
 VERIFY_MODEL_CHECKSUMS="${VERIFY_MODEL_CHECKSUMS:-1}"


### PR DESCRIPTION
Two-line change: `MAX_NUM_BATCHED_TOKENS` 8224 → 2048 in `start.sh`, and the matching README row.

`max_num_batched_tokens` also sizes vLLM's profiling dummy forward, and the resulting
"peak activation" is subtracted from the KV pool. Controlled A/B on a single GB10 —
`MAX_MODEL_LEN=262144`, util 0.93, capture sizes `{6}`, everything else stock, same
60,067-token random-word prompt in both arms with `cached_tokens: 0` verified:

| `MAX_NUM_BATCHED_TOKENS` | peak activation | prefill | KV pool (that boot) |
|---|---|---|---|
| 8224 | 5.30 GiB | 997 tok/s | 290,632 tok |
| 2048 | **1.39 GiB** | **1013 tok/s** | 1,262,567 tok |

Prefill is unchanged within noise — which is the point. If the scheduler were really
issuing 8224-token chunks, the 2048 arm would have paid for it. It didn't, consistent
with `LONG_PREFILL_TOKEN_THRESHOLD=1024` (your default) capping what a step allocates.

The recovered 3.9 GiB is directly usable as context. At 8224, `MAX_MODEL_LEN=1048576`
does not boot:

```
ValueError: To serve at least one request with the model's max seq len (1048576),
9.8 GiB KV cache is needed, which is larger than the available KV cache memory (4.81 GiB).
```

At 2048 it boots and answers a **1,047,039-token** needle prompt (`cached_tokens: 0`,
random-word filler) with exact recall of needles at the head *and* the midpoint —
30.9 min wall, 564 tok/s average prefill, 0 preemptions. Decode untouched: 45.3 tok/s
pure decode, DSpark K5 acceptance 55–67%, 4.33 tokens per step.

Deliberately **not** in this PR: `GPU_MEMORY_UTILIZATION` stays at 0.94 (it boots on your
host; lowering it would be me projecting my own headroom onto your default) and
`CUDAGRAPH_CAPTURE_SIZES` stays as-is (the 0.07 GiB at stake doesn't justify a change I
haven't A/B'd for decode). Full measurements, including the caveat that the reported pool
in *tokens* is not comparable across boots, are in the companion issue.